### PR TITLE
loading bar lost weight

### DIFF
--- a/frontend/src/components/loadingBar.svelte
+++ b/frontend/src/components/loadingBar.svelte
@@ -73,7 +73,7 @@
         precision={2}
         tweenDuration={1500}
         easing={sineOut}
-        size="h-6"
+        size="h-2"
         class="self-center"
         color="blue"
     />


### PR DESCRIPTION
reduced height of loading bar so it actually looks like the figma design + needed to be skinny inside the 'regenerating' popup