### PR TITLE
Completed front-end of regeneration variant of pop-up

### DIFF
--- a/frontend/src/components/popUpModal.svelte
+++ b/frontend/src/components/popUpModal.svelte
@@ -3,7 +3,7 @@
     Contains pop-up modal
 
     Author: Brenda Dang
-    Modified by: Bowen Dong
+    Modified by: Bowen Dong, Diya Ramesh
     Last modified: 9/08/2024
 
 -->
@@ -11,6 +11,7 @@
 <script>
     import Button from "./button.svelte";
     import errorIcon from "../assets/error-icon.png";
+    import { Progressbar } from 'flowbite-svelte';
 
     export let type = 'primary';  // Default type is primary (blue with 1 button)
     export let firstHandleClick = () => {};  // Click function for primary button (dark blue, or red)
@@ -30,7 +31,7 @@
 </script>
 
 <body>
-    {#if visible}
+    <!-- {#if visible} -->
     <div class="justify-center items-center font-sans h-full transition ease-in-out duration-300">
         <div class="fixed inset-0 flex items-center justify-center w-full h-full bg-black backdrop-blur md:bg-opacity-70">
             <div class="bg-white rounded-lg p-4 w-{width}">
@@ -49,7 +50,17 @@
                 <div class="flex items-center justify-center text-gray-500 text-sm pt-2">
                     {mainText}
                 </div>
-                {#if type === 'secondary'}
+                {#if type === 'loading'}
+                <div class="flex flex-col items-center pt-4 gap-4">
+                    <Progressbar progress="50" color="blue" />
+                    <Button
+                        type='primary'
+                        text='Cancel'
+                        fullWidth={true}
+                        handleClick={firstHandleClick}
+                    />
+                </div>
+                {:else if type === 'secondary'}
                 <div class="flex shrink justify-evenly object-cover pb-1 pt-8 items-center">
                     <div class = "w-5/12">
                         <Button 
@@ -81,7 +92,7 @@
             </div>
         </div>
     </div>
-    {/if}
+    <!-- {/if} -->
 </body>
 
 <!--

--- a/frontend/src/routes/generate_summary/+page.svelte
+++ b/frontend/src/routes/generate_summary/+page.svelte
@@ -2,7 +2,7 @@
 
     Page that shows the summary generated
 
-    Author:Brenda Dang, Diya Ramesh
+    Author: Brenda Dang, Diya Ramesh
     Last Modified: 1/08/2024
 -->
 
@@ -12,6 +12,7 @@
     import SummaryBox from "../../components/summary-box.svelte";
     import { goto } from "$app/navigation";
     import { summaryStore } from "../../stores/summary-store";
+    import PopUpModal from "../../components/popUpModal.svelte";
 
     export let title;
     export let subTitle;
@@ -41,6 +42,14 @@
         goto("/email");
     };
 
+    let displayPopUp = false;
+
+    function togglePopUp() {
+        displayPopUp = !displayPopUp;
+    }
+
+
+
     // onMount(() => {
     //     const interval = setInterval(hasSummaryGenerated, 1000);
 
@@ -57,6 +66,19 @@
 
 <body>
     <TopBar />
+    
+    <!-- REGENERATING POPUP MODAL
+    <button on:click={togglePopUp}>Show Loading Modal</button>
+    
+    {#if displayPopUp}
+        <PopUpModal 
+        header="Regenerating..."
+        mainText=""
+        type='loading'
+        firstHandleClick={togglePopUp}
+        width='96'/>
+    {/if} -->
+    
 
     <div class="text-4xl font-inter font-bold mb-4 text-black flex flex-col justify-center items-center mt-20">
         {hasSummaryGenerated ? "Summary Generated!" : "Your Summary is Being Generated..."}


### PR DESCRIPTION
An example of displaying this is shown in the /generate_summary page. The progress bar will need to be modified according to the summary generation itself and this will need to be rendered when the "Regenerate" button is clicked.

I reckon e will need to create another user story to modify the popUpModal component to store the visibility state in a svelte store in order to access it outside this component